### PR TITLE
Update/datadog template

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ This solution deploys a set of AWS resources across your AWS Organization to ena
 - **`stacksets/metrics/stackset.yaml`**, **`stacksets/metrics/oam-link-template.yaml`**, and **`stacksets/metrics/cw-cross-account-sharing-template.yaml`**: Deploy OAM Links and cross-account sharing roles to enable metric sharing from member accounts to the central account.
 - **`stacksets/datadog-shipping/stackset.yaml`** and related templates: Deploy resources in the central account to receive logs/metrics and forward them to Datadog.
 - **Root-level templates** (e.g., `template.yaml`, `stacksets-shipping-template.yaml`): Compose and orchestrate the deployment of the above stacksets and templates for a full organization-wide rollout.
+
+## Datadog template Updates
+
+Due to a limitation in AWS SAM's `package` command in `template.yaml` the `DatadogIntegrationStack` `Location` parameter must be kept in sync manually with the `DatadogTemplateUrl` value.

--- a/cfn-parameters.json
+++ b/cfn-parameters.json
@@ -8,5 +8,6 @@
     "DatadogApiKey": $secrets.DATADOG_API_KEY,
     "DatadogAppKey": $secrets.DATADOG_APP_KEY,
     "DataDogLogsDestinationArn": $secrets.DATADOG_LOGS_DESTINATION_ARN,
-    "DatadogSite": "us5.datadoghq.com"
+    "DatadogSite": "us5.datadoghq.com",
+    "DatadogTemplateUrl": $vars.DATADOG_TEMPLATE_URL
 }

--- a/stacksets-shipping-template.yaml
+++ b/stacksets-shipping-template.yaml
@@ -13,6 +13,8 @@ Parameters:
     Type: String
   ObservabilityOu:
     Type: String
+  DatadogTemplateUrl:
+    Type: String
   DatadogSite:
     Type: String
   DatadogApiKey:
@@ -28,17 +30,18 @@ Parameters:
     Type: String
 
 Resources:
-#  DatadogIntegrationStackSet:
-#    Type: AWS::Serverless::Application
-#    Properties:
-#      Location: "./stacksets/datadog-integration/stackset.yaml"
-#      Parameters:
-#        DeploymentOrgId: !Ref AwsOrgRootId
-#        TargetRegions: !Ref TargetRegions
-#        DatadogApiKey: !Ref DatadogApiKey
-#        DatadogAppKey: !Ref DatadogAppKey
-#        DatadogSite: !Ref DatadogSite
-#        DisableMetricCollection: 'false'
+  DatadogIntegrationStackSet:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: "./stacksets/datadog-integration/stackset.yaml"
+      Parameters:
+        DeploymentOrgId: !Ref AwsOrgRootId
+        TargetRegions: !Ref TargetRegions
+        DatadogTemplateUrl: !Ref DatadogTemplateUrl
+        DatadogApiKey: !Ref DatadogApiKey
+        DatadogAppKey: !Ref DatadogAppKey
+        DatadogSite: !Ref DatadogSite
+        DisableMetricCollection: 'false'
 
   LogShippingStackSet:
     Type: AWS::Serverless::Application

--- a/stacksets/datadog-integration/stackset.yaml
+++ b/stacksets/datadog-integration/stackset.yaml
@@ -7,6 +7,8 @@ Parameters:
     Type: CommaDelimitedList
   TargetRegions:
     Type: CommaDelimitedList
+  DatadogTemplateUrl:
+    Type: String
   DatadogSite:
     Type: String
   DatadogApiKey:
@@ -51,4 +53,4 @@ Resources:
         FailureToleranceCount: 1
         MaxConcurrentCount: 5
       PermissionModel: SERVICE_MANAGED
-      TemplateURL: https://datadog-cloudformation-template.s3.amazonaws.com/aws/main_organizations.yaml
+      TemplateURL: !Ref DatadogTemplateUrl

--- a/template.yaml
+++ b/template.yaml
@@ -11,6 +11,8 @@ Parameters:
     Type: String
   ObservabilityOu:
     Type: String
+  DatadogTemplateUrl:
+    Type: String
   DatadogSite:
     Type: String
   DatadogApiKey:
@@ -26,15 +28,15 @@ Parameters:
     Type: String
 
 Resources:
-#  DatadogIntegrationStack:
-#    Type: AWS::Serverless::Application
-#    Properties:
-#      Location: "https://datadog-cloudformation-template.s3.amazonaws.com/aws/main_organizations.yaml"
-#      Parameters:
-#        DatadogApiKey: !Ref DatadogApiKey
-#        DatadogAppKey: !Ref DatadogAppKey
-#        DatadogSite: !Ref DatadogSite
-#        DisableMetricCollection: 'false'
+  DatadogIntegrationStack:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: !Ref DatadogTemplateUrl
+      Parameters:
+        DatadogApiKey: !Ref DatadogApiKey
+        DatadogAppKey: !Ref DatadogAppKey
+        DatadogSite: !Ref DatadogSite
+        DisableMetricCollection: 'false'
 
   LogShippingStack:
     Type: AWS::Serverless::Application

--- a/template.yaml
+++ b/template.yaml
@@ -11,6 +11,8 @@ Parameters:
     Type: String
   ObservabilityOu:
     Type: String
+  # WARNING: due to a limitation of AWS SAM's `package` command the DatadogIntegrationStack
+  # Location parameter must be kept in sync manually.
   DatadogTemplateUrl:
     Type: String
   DatadogSite:
@@ -31,7 +33,7 @@ Resources:
   DatadogIntegrationStack:
     Type: AWS::Serverless::Application
     Properties:
-      Location: !Ref DatadogTemplateUrl
+      Location: "https://datadog-cloudformation-template-quickstart.s3.amazonaws.com/aws/v4.1.3/main_orgnizations.yaml"
       Parameters:
         DatadogApiKey: !Ref DatadogApiKey
         DatadogAppKey: !Ref DatadogAppKey


### PR DESCRIPTION
Updates the datadogintegration template used to v2.

there is no direct migration path from v1 to v2 so will be pulling the existing template in a separate branch, deploying, and finally merging this.